### PR TITLE
Remove debug endpoint for security enhancement

### DIFF
--- a/server.js
+++ b/server.js
@@ -183,40 +183,6 @@ app.get('/api/health', (req, res) => {
   });
 });
 
-// Debug endpoint to check if files exist
-app.get('/api/debug', (req, res) => {
-  const fs = require('fs');
-  const publicPath = path.join(__dirname, 'public');
-  
-  try {
-    const files = fs.readdirSync(publicPath);
-    const fileStats = {};
-    
-    files.forEach(file => {
-      const filePath = path.join(publicPath, file);
-      const stats = fs.statSync(filePath);
-      fileStats[file] = {
-        size: stats.size,
-        modified: stats.mtime
-      };
-    });
-    
-    res.json({
-      publicPath,
-      files,
-      fileStats,
-      __dirname,
-      cwd: process.cwd()
-    });
-  } catch (error) {
-    res.status(500).json({
-      error: error.message,
-      publicPath,
-      __dirname,
-      cwd: process.cwd()
-    });
-  }
-});
 
 app.get('/', (req, res) => {
   res.sendFile(path.join(__dirname, 'public', 'index.html'));


### PR DESCRIPTION
## Summary
- Removed /api/debug endpoint that exposed sensitive system information
- Eliminates potential information disclosure vulnerability
- Improves overall application security posture

The debug endpoint was exposing internal file system paths, working directory, and other system details that could be useful for attackers.