### PR TITLE
Fix GitHub authentication button labels

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -102,14 +102,14 @@
                         <svg width="14" height="14" fill="currentColor" viewBox="0 0 16 16">
                             <path d="M8 0C3.58 0 0 3.58 0 8c0 3.54 2.29 6.53 5.47 7.59.4.07.55-.17.55-.38 0-.19-.01-.82-.01-1.49-2.01.37-2.53-.49-2.69-.94-.09-.23-.48-.94-.82-1.13-.28-.15-.68-.52-.01-.53.63-.01 1.08.58 1.23.82.72 1.21 1.87.87 2.33.66.07-.52.28-.87.51-1.07-1.78-.2-3.64-.89-3.64-3.95 0-.87.31-1.59.82-2.15-.08-.2-.36-1.02.08-2.12 0 0 .67-.21 2.2.82.64-.18 1.32-.27 2-.27.68 0 1.36.09 2 .27 1.53-1.04 2.2-.82 2.2-.82.44 1.1.16 1.92.08 2.12.51.56.82 1.27.82 2.15 0 3.07-1.87 3.75-3.65 3.95.29.25.54.73.54 1.48 0 1.07-.01 1.93-.01 2.2 0 .21.15.46.55.38A8.012 8.012 0 0 0 16 8c0-4.42-3.58-8-8-8z"/>
                         </svg>
-                        <span data-i18n="auth.login">GitHub</span>
+                        <span data-i18n="auth.login">Login with GitHub</span>
                     </button>
                     
                     <!-- User info (shown when authenticated) -->
                     <div class="user-info" id="userInfo" style="display: none;">
                         <img class="user-avatar" id="userAvatar" src="" alt="User Avatar">
                         <span class="user-name" id="userName"></span>
-                        <button class="logout-btn" id="logoutBtn" onclick="logout()" data-i18n="auth.logout">Sair</button>
+                        <button class="logout-btn" id="logoutBtn" onclick="logout()" data-i18n="auth.logout">Logout</button>
                     </div>
                 </div>
             </div>


### PR DESCRIPTION
## Summary
- Fixed GitHub login button text to display "Login with GitHub" instead of just "GitHub"
- Updated logout button text to display "Logout" instead of "Sair" for English consistency
- Improves user experience with clearer authentication action labels

## Test plan
- [ ] Verify login button shows "Login with GitHub" when not authenticated
- [ ] Verify logout button shows "Logout" when authenticated
- [ ] Test authentication flow works correctly
- [ ] Confirm i18n translations still work properly