### PR TITLE
Improve UX: Show/hide endpoints based on connection status

### DIFF
--- a/public/app.js
+++ b/public/app.js
@@ -86,6 +86,9 @@ class SocketManager {
             this.isReconnecting = false;
             updateConnectionStatus();
             
+            // Reload user endpoints when reconnecting
+            loadUserEndpoints();
+            
             if (state.currentEndpoint) {
                 this.socket.emit('join-endpoint', state.currentEndpoint.id);
                 setTimeout(() => loadRequests(), 1000);
@@ -96,6 +99,13 @@ class SocketManager {
             console.log('Disconnected from server');
             state.isConnected = false;
             updateConnectionStatus();
+            
+            // Hide endpoints section when disconnected
+            const endpointsSection = document.getElementById('userEndpointsSection');
+            if (endpointsSection) {
+                endpointsSection.style.display = 'none';
+            }
+            
             this.scheduleReconnect();
         });
 


### PR DESCRIPTION
## Summary
- Automatically show user endpoints when socket connects/reconnects
- Hide endpoints section when socket disconnects for cleaner interface
- Maintains existing migration functionality for anonymous users

## Test plan
- [ ] Test endpoint visibility on connect/disconnect
- [ ] Verify endpoints reappear after reconnection
- [ ] Confirm anonymous user migration still works
- [ ] Test with multiple users and different connection states