### PR TITLE
Fix: Preserve anonymous endpoints after GitHub logout

### DIFF
--- a/public/app.js
+++ b/public/app.js
@@ -646,10 +646,19 @@ function renderEndpointsList(endpoints) {
             i18n.getCurrentLanguage() === 'pt-BR' ? 'pt-BR' : 'en-US'
         );
         
+        // Check if endpoint belongs to anonymous user
+        const isAnonymous = endpoint.user_id && endpoint.user_id.startsWith('user_anonymous_');
+        const userBadge = isAnonymous ? 
+            '<span class="endpoint-user-badge anonymous">👤 Anônimo</span>' : 
+            '<span class="endpoint-user-badge github">🔗 GitHub</span>';
+        
         return `
             <div class="endpoint-item ${isActive ? 'active' : ''}" data-endpoint-id="${endpoint.id}" ${!isActive ? `onclick="switchToEndpoint('${endpoint.id}')"` : ''} style="${!isActive ? 'cursor: pointer;' : ''}">
                 <div class="endpoint-item-header">
-                    <div class="endpoint-item-name">${endpoint.name}</div>
+                    <div class="endpoint-item-name">
+                        ${endpoint.name}
+                        ${userBadge}
+                    </div>
                     <div class="endpoint-item-actions">
                         <button class="endpoint-action-btn delete" onclick="event.stopPropagation(); deleteEndpoint('${endpoint.id}')" title="${i18n.t('user.endpoints.delete')}">🗑️</button>
                     </div>

--- a/public/auth-manager.js
+++ b/public/auth-manager.js
@@ -173,16 +173,18 @@ class AuthManager {
                 if (typeof userManager !== 'undefined') {
                     userManager.isAuthenticated = false;
                     userManager.githubUser = null;
-                    userManager.userEndpoints = [];
+                    // Don't clear userEndpoints - preserve anonymous endpoints
                 }
                 
                 this.updateAuthUI();
                 this.showMessage('Logged out successfully.', 'success');
                 
-                // Reload page to reset any user-specific data
+                // Reload anonymous user endpoints instead of full page reload
                 setTimeout(() => {
-                    window.location.reload();
-                }, 1000);
+                    if (typeof loadUserEndpoints !== 'undefined') {
+                        loadUserEndpoints();
+                    }
+                }, 500);
             } else {
                 this.showMessage('Logout failed. Please try again.', 'error');
             }

--- a/public/style.css
+++ b/public/style.css
@@ -126,6 +126,31 @@ body {
     font-weight: bold;
     color: #58a6ff;
     font-size: 13px;
+    display: flex;
+    align-items: center;
+    gap: 8px;
+}
+
+.endpoint-user-badge {
+    font-size: 10px;
+    padding: 2px 6px;
+    border-radius: 12px;
+    font-weight: 500;
+    display: inline-flex;
+    align-items: center;
+    gap: 3px;
+}
+
+.endpoint-user-badge.anonymous {
+    background-color: rgba(139, 148, 158, 0.15);
+    color: #8b949e;
+    border: 1px solid rgba(139, 148, 158, 0.3);
+}
+
+.endpoint-user-badge.github {
+    background-color: rgba(88, 166, 255, 0.15);
+    color: #58a6ff;
+    border: 1px solid rgba(88, 166, 255, 0.3);
 }
 
 .endpoint-item-actions {


### PR DESCRIPTION
## Summary
- Remove unnecessary endpoint clearing during GitHub logout
- Replace full page reload with selective endpoint reloading 
- Add visual badges to distinguish GitHub vs anonymous endpoints
- Improve user experience during login/logout state transitions

## Changes Made
- **auth-manager.js**: Remove `userEndpoints = []` clearing and page reload
- **app.js**: Add user badges (GitHub 🔗 vs Anonymous 👤) to endpoint list
- **style.css**: Add styling for endpoint user badges

## Test Plan
- [ ] Test GitHub logout preserves anonymous endpoints
- [ ] Verify endpoint badges display correctly
- [ ] Confirm smooth login/logout transitions without page reload
- [ ] Test endpoint functionality remains intact