### PR TITLE
Fix endpoint deletion error and remove debug logs

### DIFF
--- a/public/app.js
+++ b/public/app.js
@@ -655,7 +655,7 @@ function renderEndpointsList(endpoints) {
         let userBadge;
         if (isAnonymous) {
             userBadge = '<span class="endpoint-user-badge anonymous">👤 Anônimo</span>';
-        } else if (isOwnedByCurrentUser || (!isAnonymous && currentUserIsAuthenticated)) {
+        } else if (isOwnedByCurrentUser) {
             userBadge = '<span class="endpoint-user-badge github">🔗 GitHub</span>';
         } else {
             userBadge = '<span class="endpoint-user-badge anonymous">👤 Anônimo</span>';

--- a/public/auth-manager.js
+++ b/public/auth-manager.js
@@ -67,13 +67,11 @@ class AuthManager {
                     this.updateAuthUI();
                     // Explicitly update userManager state before context update
                     if (userManager) {
-                        console.log('Updating userManager state after login');
                         userManager.isAuthenticated = this.isAuthenticated;
                         userManager.githubUser = this.currentUser;
                         
                         if (typeof userManager.updateUserContext === 'function') {
                             userManager.updateUserContext().then(() => {
-                                console.log('User context updated, reloading endpoints');
                                 // Reload endpoints after migration
                                 if (typeof loadUserEndpoints === 'function') {
                                     loadUserEndpoints();
@@ -96,13 +94,11 @@ class AuthManager {
                     this.updateAuthUI();
                     // Explicitly update userManager state before context update
                     if (userManager) {
-                        console.log('Updating userManager state after test login');
                         userManager.isAuthenticated = this.isAuthenticated;
                         userManager.githubUser = this.currentUser;
                         
                         if (typeof userManager.updateUserContext === 'function') {
                             userManager.updateUserContext().then(() => {
-                                console.log('User context updated, reloading endpoints');
                                 // Reload endpoints after migration
                                 if (typeof loadUserEndpoints === 'function') {
                                     loadUserEndpoints();


### PR DESCRIPTION
## Problem
Users were getting error "Endpoint not found or not owned by user" when trying to delete endpoints after logging in.

## Root Cause
The `deleteEndpoint()` method was using `this.currentUser.id` (anonymous user ID) instead of `this.getApiUserId()` which returns the correct user ID based on authentication state:
- GitHub user ID when logged in
- Anonymous user ID when not logged in

## Solution
- **Fix endpoint deletion**: Use `getApiUserId()` to get correct user ID for API calls
- **Clean up debug logs**: Remove all `console.log` statements added during debugging  
- **Improve badge logic**: Simplify endpoint badge rendering for better accuracy

## Technical Changes
### `user-manager.js`
- Fix `deleteEndpoint()` to use `getApiUserId()` instead of `currentUser.id`
- Remove debug logs from `updateUserContext()` and `migrateEndpoints()`
- Clean up migration logging while keeping error handling

### `auth-manager.js`  
- Remove debug logs from login callbacks
- Maintain functionality while cleaning up verbose logging

### `app.js`
- Simplify badge rendering logic for better precision
- Remove overly broad condition that could cause incorrect badges

## Testing
- ✅ Create anonymous endpoint → shows "Anônimo" badge
- ✅ Login → endpoint migrates and shows "GitHub" badge  
- ✅ Create new endpoint after login → shows "GitHub" badge
- ✅ **Delete endpoint after login → works without error** 🎯
- ✅ Logout → shows only anonymous endpoints

## Impact
- Fixes critical endpoint deletion functionality for authenticated users
- Removes debugging noise from console  
- Maintains all migration and authentication features
- Improves code quality and user experience