### PR TITLE
Fix: Clear active endpoint completely on logout

### DIFF
--- a/public/auth-manager.js
+++ b/public/auth-manager.js
@@ -211,6 +211,11 @@ class AuthManager {
                     userManager.updateUserContext();
                 }
                 
+                // Clear any active endpoint from UI
+                if (typeof clearActiveEndpoint !== 'undefined') {
+                    clearActiveEndpoint();
+                }
+                
                 this.updateAuthUI();
                 this.showMessage('Logged out successfully.', 'success');
                 


### PR DESCRIPTION
## Problem
After logout, the active endpoint remained visible in the UI with:
- URL still displayed and copyable
- Endpoint info sections still visible  
- Still listening to webhook requests
- Socket connection to endpoint room still active

## Root Cause
The logout process was not clearing the active endpoint state, leaving:
- `state.currentEndpoint` populated
- UI sections visible (`endpointUrlContainer`, `endpointInfo`, etc.)
- Socket still connected to endpoint room
- Request listening still active

## Solution
- **Add `clearActiveEndpoint()` function**: Centralized function to properly clean all endpoint state
- **Clean logout process**: Call `clearActiveEndpoint()` during logout
- **Socket cleanup**: Leave endpoint room when clearing active endpoint
- **UI cleanup**: Hide all endpoint-related UI sections
- **State cleanup**: Clear global state and localStorage

## Technical Changes
### `app.js`
- **New `clearActiveEndpoint()` function**: 
  - Leaves socket room (`socket.emit('leave-endpoint')`)
  - Clears global state (`state.currentEndpoint = null`)
  - Removes from localStorage (`userManager.setCurrentEndpoint(null)`)
  - Hides UI sections (URL container, info, controls, requests)
  - Updates connection status and request list

- **Enhanced `loadUserEndpoints()`**:
  - Validates if current endpoint still exists
  - Clears endpoint if not available to user
  - Handles case when no endpoints are available

- **Refactored `deleteEndpoint()`**: 
  - Uses shared `clearActiveEndpoint()` function
  - Eliminates code duplication

### `auth-manager.js`
- **Enhanced logout process**: 
  - Calls `clearActiveEndpoint()` after clearing user data
  - Ensures complete UI cleanup before reloading endpoints

## Testing Instructions
1. **Login and create/select an endpoint** → endpoint should be active and visible
2. **Verify active state**: URL visible, listening to requests, controls available
3. **Logout** → should immediately see:
   - ✅ URL container disappears
   - ✅ Endpoint info section hidden  
   - ✅ Controls section hidden
   - ✅ Requests container hidden
   - ✅ Stops listening to webhooks
   - ✅ Socket leaves endpoint room
4. **Verify clean state**: Only anonymous endpoints (if any) should be visible

## Impact
- **Complete logout cleanup**: No endpoint state remains after logout
- **Better security**: User can't access GitHub endpoints after logout  
- **Cleaner UX**: UI properly reflects authentication state
- **Resource efficiency**: Stops unnecessary socket connections
- **Code quality**: Reusable `clearActiveEndpoint()` function

## Additional Benefits
- Handles edge cases where endpoint becomes unavailable
- Prevents orphaned UI state
- Consistent behavior between logout and endpoint deletion
- Improved maintainability with shared cleanup logic