### PR TITLE
Add loading indicator for endpoints

### DIFF
--- a/public/app.js
+++ b/public/app.js
@@ -610,8 +610,21 @@ async function clearRequests() {
 
 // Load user endpoints and display them
 async function loadUserEndpoints() {
+    const endpointsSection = document.getElementById('userEndpointsSection');
+    const endpointsLoading = document.getElementById('endpointsLoading');
+    const endpointsList = document.getElementById('endpointsList');
+    
     try {
+        // Show loading and hide list
+        endpointsLoading.style.display = 'flex';
+        endpointsList.style.display = 'none';
+        
         const endpoints = await userManager.loadUserEndpoints();
+        
+        // Hide loading and show list
+        endpointsLoading.style.display = 'none';
+        endpointsList.style.display = 'block';
+        
         renderEndpointsList(endpoints);
         
         // Check if current active endpoint is still available
@@ -623,7 +636,6 @@ async function loadUserEndpoints() {
         }
         
         // Show the endpoints section if there are endpoints
-        const endpointsSection = document.getElementById('userEndpointsSection');
         if (endpoints.length > 0) {
             endpointsSection.style.display = 'block';
         } else {
@@ -635,6 +647,9 @@ async function loadUserEndpoints() {
         }
     } catch (error) {
         console.error('Error loading user endpoints:', error);
+        // Hide loading on error
+        endpointsLoading.style.display = 'none';
+        endpointsList.style.display = 'block';
     }
 }
 

--- a/public/index.html
+++ b/public/index.html
@@ -155,6 +155,10 @@
 
         <div class="user-endpoints-section" id="userEndpointsSection" style="display: none;">
             <h3 data-i18n="user.endpoints.title">Meus Endpoints</h3>
+            <div class="endpoints-loading" id="endpointsLoading" style="display: none;">
+                <span class="loading-spinner"></span>
+                <span data-i18n="loading.endpoints">Carregando endpoints...</span>
+            </div>
             <div class="endpoints-list" id="endpointsList">
                 <!-- Endpoints will be populated here -->
             </div>

--- a/public/locales/en.json
+++ b/public/locales/en.json
@@ -58,6 +58,7 @@
   "status.monitoring": "Monitoring",
   
   "loading.text": "Loading...",
+  "loading.endpoints": "Loading endpoints...",
   
   "no.requests.title": "Waiting for webhooks...",
   "no.requests.description": "Send a request to your endpoint URL to see details here",

--- a/public/locales/pt-BR.json
+++ b/public/locales/pt-BR.json
@@ -58,6 +58,7 @@
   "status.monitoring": "Monitorando",
   
   "loading.text": "Carregando...",
+  "loading.endpoints": "Carregando endpoints...",
   
   "no.requests.title": "Aguardando webhooks...",
   "no.requests.description": "Envie uma requisição para a URL do seu endpoint para ver os detalhes aqui",

--- a/public/style.css
+++ b/public/style.css
@@ -711,6 +711,21 @@ body {
     animation: spin 1s ease-in-out infinite;
 }
 
+.endpoints-loading {
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    gap: 10px;
+    padding: 20px;
+    color: #8b949e;
+    font-size: 14px;
+}
+
+.endpoints-loading .loading-spinner {
+    width: 20px;
+    height: 20px;
+}
+
 @keyframes spin {
     to { transform: rotate(360deg); }
 }


### PR DESCRIPTION
## Summary
- Added loading indicator for the endpoints section while loading/updating endpoints
- Shows spinner and loading text to provide user feedback during async operations
- Applied to both Portuguese and English translations
- Improved UX by providing visual feedback during endpoint operations

## Changes Made
- Added loading HTML elements to index.html
- Added CSS styling for loading indicator
- Added JavaScript functionality to show/hide loading state
- Added translations for loading text in both languages

## Test plan
- [x] Test loading indicator appears when endpoints are being loaded
- [x] Test loading indicator is hidden when endpoints load successfully
- [x] Test loading indicator works in both Portuguese and English
- [x] Test loading indicator styling matches the application theme