### PR TITLE
Fix Google Analytics CSP errors and simplify loading

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -70,18 +70,15 @@
     <script src="user-manager.js"></script>
     <script src="auth-manager.js"></script>
     
-    <!-- Google tag (gtag.js) - Conditional loading with silent fallback -->
+    <!-- Google tag (gtag.js) -->
     <script>
       // Initialize dataLayer for gtag
       window.dataLayer = window.dataLayer || [];
       function gtag(){
-        if (window.dataLayer) {
-          dataLayer.push(arguments);
-        }
+        dataLayer.push(arguments);
       }
       
-      // Only attempt to load Google Analytics in production environments
-      // and only if the current domain suggests a production environment
+      // Only load Google Analytics in production environments
       const isProd = window.location.hostname === 'hookdebug.com' || 
                      (window.location.hostname !== 'localhost' && 
                       window.location.hostname !== '127.0.0.1' && 
@@ -89,25 +86,15 @@
                       !window.location.hostname.includes('staging'));
       
       if (isProd) {
-        // Test connectivity to Google first
-        fetch('https://www.google.com/favicon.ico', { method: 'HEAD', mode: 'no-cors' })
-          .then(() => {
-            // Google is reachable, load analytics
-            const script = document.createElement('script');
-            script.async = true;
-            script.src = 'https://www.googletagmanager.com/gtag/js?id=G-EFLN6DVLBL';
-            script.onerror = function() {
-              // Silent fallback - no console noise
-            };
-            script.onload = function() {
-              gtag('js', new Date());
-              gtag('config', 'G-EFLN6DVLBL');
-            };
-            document.head.appendChild(script);
-          })
-          .catch(() => {
-            // Google not reachable, skip analytics silently
-          });
+        // Load Google Analytics script
+        const script = document.createElement('script');
+        script.async = true;
+        script.src = 'https://www.googletagmanager.com/gtag/js?id=G-EFLN6DVLBL';
+        script.onload = function() {
+          gtag('js', new Date());
+          gtag('config', 'G-EFLN6DVLBL');
+        };
+        document.head.appendChild(script);
       }
     </script>
 </head>

--- a/src/middleware/security.js
+++ b/src/middleware/security.js
@@ -55,7 +55,7 @@ const securityHeaders = (req, res, next) => {
         "script-src 'self' 'unsafe-inline' https://cdnjs.cloudflare.com https://www.googletagmanager.com https://www.google-analytics.com; " +
         "style-src 'self' 'unsafe-inline' https://cdnjs.cloudflare.com; " +
         "img-src 'self' data: https://avatars.githubusercontent.com; " +
-        "connect-src 'self' https://www.google-analytics.com https://analytics.google.com https://www.googletagmanager.com;"
+        "connect-src 'self' https://www.google-analytics.com https://analytics.google.com https://www.googletagmanager.com https://www.google.com;"
     );
     
     next();


### PR DESCRIPTION
## Summary
- Fixed Content Security Policy (CSP) violations causing Google Analytics errors
- Removed unnecessary connectivity test that was blocked by CSP
- Simplified Google Analytics loading logic for better reliability

## Changes
- **CSP Update**: Added `https://www.google.com` to `connect-src` directive in security middleware
- **Google Analytics**: Removed problematic `fetch()` test to `www.google.com/favicon.ico`
- **Code Simplification**: Streamlined Google Analytics loading without unnecessary error handling

## Test plan
- [x] Verify no CSP errors in browser console
- [x] Confirm Google Analytics loads properly in production environment
- [x] Test that application functionality remains unchanged

## Fixes
Resolves console errors:
- `Refused to connect to 'https://www.google.com/favicon.ico' because it violates CSP`
- `Fetch API cannot load https://www.google.com/favicon.ico`