### PR TITLE
Fix translation and date format issues in My Endpoints section

### DIFF
--- a/public/app.js
+++ b/public/app.js
@@ -899,6 +899,11 @@ async function changeLanguage(language) {
         updateEndpointUI(state.currentEndpoint);
     }
     
+    // Re-render endpoints list to update dates and translations
+    if (userManager.isAuthenticated) {
+        await loadUserEndpoints();
+    }
+    
     // Update any visible messages
     const errorDiv = document.getElementById('errorMessage');
     const successDiv = document.getElementById('successMessage');


### PR DESCRIPTION
## Summary
- Fixed "Created on:" text not translating when language changes in My Endpoints section
- Fixed date format not updating to match selected language locale (pt-BR/en-US)
- Added endpoints list re-rendering on language change to ensure proper updates

## Test plan
- [x] Switch between Portuguese and English languages
- [x] Verify "Created on:" text translates correctly
- [x] Verify date format changes according to selected language
- [x] Ensure endpoints list updates properly on language change