### PR TITLE
Fix endpoints disappearing after page refresh

### DIFF
--- a/public/app.js
+++ b/public/app.js
@@ -854,7 +854,7 @@ async function loadCleanupInfo() {
 }
 
 // Event listeners
-document.addEventListener('DOMContentLoaded', () => {
+document.addEventListener('DOMContentLoaded', async () => {
     // Initialize i18n system
     i18n.initializeLanguage();
     
@@ -862,8 +862,8 @@ document.addEventListener('DOMContentLoaded', () => {
     socketManager.connect();
     state.socket = socketManager.socket;
     
-    // Load user endpoints and saved endpoint
-    loadUserEndpoints();
+    // Load user endpoints first, then load saved endpoint
+    await loadUserEndpoints();
     loadSavedEndpoint();
     loadCleanupInfo();
     


### PR DESCRIPTION
## Summary
- Fixed bug where user endpoints would disappear after page refresh
- The issue was a race condition where `loadSavedEndpoint()` was called before `loadUserEndpoints()` finished loading
- This caused the saved endpoint to be considered invalid and removed from localStorage

## Changes
- Made `DOMContentLoaded` event listener async
- Added `await` before `loadUserEndpoints()` to ensure endpoints are loaded before validation
- Now endpoints persist correctly after page refresh

## Test plan
- [x] Create an endpoint and verify it appears in the list
- [x] Refresh the page and verify endpoint still appears
- [x] Verify switching between endpoints still works
- [x] Verify endpoint deletion still works