### PR TITLE
Fix hard-coded backend URL

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -2,6 +2,7 @@ import { useState, useEffect } from 'react';
 import { HttpRequest, Endpoint } from './types';
 import { useSocket } from './hooks/useSocket';
 import { useAuth } from './contexts/AuthContext';
+import { BACKEND_URL } from './config';
 import { EndpointList } from './components/EndpointList';
 import { RequestList } from './components/RequestList';
 import { RequestDetails } from './components/RequestDetails';
@@ -22,7 +23,7 @@ function App() {
     const loadInitialData = async () => {
       try {
         // Load endpoints
-        const endpointsResponse = await fetch('http://localhost:3001/api/endpoints', {
+        const endpointsResponse = await fetch(`${BACKEND_URL}/api/endpoints`, {
           credentials: 'include'
         });
         if (endpointsResponse.ok) {
@@ -31,7 +32,7 @@ function App() {
         }
 
         // Load requests
-        const requestsResponse = await fetch('http://localhost:3001/api/requests', {
+        const requestsResponse = await fetch(`${BACKEND_URL}/api/requests`, {
           credentials: 'include'
         });
         if (requestsResponse.ok) {
@@ -68,7 +69,7 @@ function App() {
 
   const handleCreateEndpoint = async (name: string) => {
     try {
-      const response = await fetch('http://localhost:3001/api/endpoints', {
+      const response = await fetch(`${BACKEND_URL}/api/endpoints`, {
         method: 'POST',
         headers: {
           'Content-Type': 'application/json',

--- a/src/components/EndpointList.tsx
+++ b/src/components/EndpointList.tsx
@@ -1,5 +1,6 @@
 import { useState } from 'react';
 import { Endpoint } from '../types';
+import { BACKEND_URL } from '../config';
 
 interface EndpointListProps {
   endpoints: Endpoint[];
@@ -18,7 +19,7 @@ export const EndpointList = ({
 
   const handleCopyUrl = async (endpoint: Endpoint, e: React.MouseEvent) => {
     e.stopPropagation();
-    const fullUrl = `http://localhost:3001/${endpoint.path}`;
+    const fullUrl = `${BACKEND_URL}/${endpoint.path}`;
     
     try {
       await navigator.clipboard.writeText(fullUrl);
@@ -67,7 +68,7 @@ export const EndpointList = ({
                   onClick={(e) => handleCopyUrl(endpoint, e)}
                   title="Click to copy URL"
                 >
-                  <span>http://localhost:3001/{endpoint.path}</span>
+                  <span>{BACKEND_URL}/{endpoint.path}</span>
                   {copiedEndpoints.has(endpoint.id) && <span className="copied-indicator">✓ Copied!</span>}
                 </div>
                 <span className="request-count">

--- a/src/config.ts
+++ b/src/config.ts
@@ -1,0 +1,1 @@
+export const BACKEND_URL = import.meta.env.VITE_BACKEND_URL || 'http://localhost:3001';

--- a/src/contexts/AuthContext.tsx
+++ b/src/contexts/AuthContext.tsx
@@ -1,4 +1,5 @@
 import { createContext, useContext, useEffect, useState, ReactNode } from 'react';
+import { BACKEND_URL } from '../config';
 
 interface User {
   id: string;
@@ -35,7 +36,7 @@ export function AuthProvider({ children }: AuthProviderProps) {
 
   const checkAuth = async () => {
     try {
-      const response = await fetch('http://localhost:3001/auth/me', {
+      const response = await fetch(`${BACKEND_URL}/auth/me`, {
         credentials: 'include',
       });
       
@@ -54,12 +55,12 @@ export function AuthProvider({ children }: AuthProviderProps) {
   };
 
   const login = () => {
-    window.location.href = 'http://localhost:3001/auth/github';
+    window.location.href = `${BACKEND_URL}/auth/github`;
   };
 
   const logout = async () => {
     try {
-      await fetch('http://localhost:3001/auth/logout', {
+      await fetch(`${BACKEND_URL}/auth/logout`, {
         method: 'POST',
         credentials: 'include',
       });

--- a/src/hooks/useSocket.ts
+++ b/src/hooks/useSocket.ts
@@ -1,13 +1,14 @@
 import { useEffect, useState } from 'react';
 import { io, Socket } from 'socket.io-client';
 import { HttpRequest, Endpoint } from '../types';
+import { BACKEND_URL } from '../config';
 
 export const useSocket = () => {
   const [socket, setSocket] = useState<Socket | null>(null);
   const [connected, setConnected] = useState(false);
 
   useEffect(() => {
-    const newSocket = io('http://localhost:3001');
+    const newSocket = io(BACKEND_URL);
     
     newSocket.on('connect', () => {
       setConnected(true);

--- a/src/vite-env.d.ts
+++ b/src/vite-env.d.ts
@@ -1,1 +1,9 @@
 /// <reference types="vite/client" />
+
+interface ImportMetaEnv {
+  readonly VITE_BACKEND_URL?: string
+}
+
+interface ImportMeta {
+  readonly env: ImportMetaEnv
+}


### PR DESCRIPTION
## Summary
- create a `BACKEND_URL` config constant
- replace localhost references with `BACKEND_URL`
- type the new environment variable in `vite-env.d.ts`

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*
- `npm test` *(fails: Missing script)*
- `docker-compose up -d` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6866cf4ee5e8832ca4318719db747e34