### PR TITLE
Remove Google Analytics and logo shadow effect

### DIFF
--- a/index.html
+++ b/index.html
@@ -46,14 +46,6 @@
     <meta name="twitter:description" content="Free webhook testing tool to inspect HTTP requests in real-time. Test APIs, webhooks, and HTTP endpoints instantly.">
     <meta name="twitter:image" content="https://hookdebug.com/logo.png">
     
-    <!-- Google Analytics -->
-    <script async src="https://www.googletagmanager.com/gtag/js?id=G-S2S0E6LQWF"></script>
-    <script>
-      window.dataLayer = window.dataLayer || [];
-      function gtag(){dataLayer.push(arguments);}
-      gtag('js', new Date());
-      gtag('config', 'G-S2S0E6LQWF');
-    </script>
   </head>
   <body>
     <div id="root"></div>

--- a/src/App.css
+++ b/src/App.css
@@ -38,7 +38,6 @@
 .app-header h1 .logo {
   height: 2.5rem;
   width: auto;
-  filter: drop-shadow(0 2px 4px rgba(0, 0, 0, 0.3));
   display: inline-block;
   vertical-align: middle;
 }


### PR DESCRIPTION
## Summary
- Remove Google Analytics tracking code that was causing console errors
- Remove drop-shadow filter from logo for cleaner visual design

## Test plan
- [x] Verify Google Analytics errors no longer appear in console
- [x] Confirm logo displays correctly without shadow effect
- [x] Test application functionality remains unchanged