### PR TITLE
Add OAuth debugging and domain configuration

### DIFF
--- a/server.js
+++ b/server.js
@@ -49,7 +49,8 @@ app.use(session({
   cookie: {
     secure: process.env.NODE_ENV === 'production',
     maxAge: 24 * 60 * 60 * 1000, // 24 hours
-    sameSite: process.env.NODE_ENV === 'production' ? 'none' : 'lax'
+    sameSite: process.env.NODE_ENV === 'production' ? 'none' : 'lax',
+    domain: process.env.NODE_ENV === 'production' ? '.hookdebug.com' : undefined
   }
 }));
 
@@ -90,6 +91,10 @@ app.get('/auth/github/callback',
   passport.authenticate('github', { failureRedirect: process.env.FRONTEND_URL }),
   async (req, res) => {
     try {
+      console.log('OAuth callback - User authenticated:', req.user ? req.user.username : 'No user');
+      console.log('OAuth callback - Session ID:', req.sessionID);
+      console.log('OAuth callback - Is authenticated:', req.isAuthenticated());
+      
       // Migrate anonymous endpoints to authenticated user
       if (req.session.anonymousEndpoints) {
         const endpointsToMigrate = JSON.parse(req.session.anonymousEndpoints);
@@ -145,6 +150,11 @@ app.post('/auth/logout', (req, res) => {
 });
 
 app.get('/auth/me', (req, res) => {
+  console.log('Auth check - Session ID:', req.sessionID);
+  console.log('Auth check - Is authenticated:', req.isAuthenticated());
+  console.log('Auth check - User:', req.user ? req.user.username : 'No user');
+  console.log('Auth check - Cookies:', req.headers.cookie);
+  
   if (req.isAuthenticated()) {
     res.json({
       user: {


### PR DESCRIPTION
## Summary
- Add comprehensive debugging for OAuth flow issues
- Improve session configuration with proper domain setting
- Enable better troubleshooting of authentication problems

## Changes Made
1. **Enhanced Session Configuration**:
   - Added `domain: '.hookdebug.com'` for production cookie sharing between subdomains
   - Ensures session cookies work across hookdebug.com and request.hookdebug.com

2. **Debug Logging Added**:
   - OAuth callback logging shows user authentication status
   - Session ID tracking for troubleshooting
   - Authentication state logging in `/auth/me` endpoint
   - Cookie headers inspection for debugging

## Why This Fix is Needed
The previous PR fixed the basic session configuration, but we still need:
1. Proper domain configuration for cross-subdomain cookies
2. Debugging visibility to identify any remaining issues
3. Better troubleshooting capabilities for OAuth flow

## Test Plan
- [ ] Deploy to production and test GitHub OAuth login
- [ ] Check server logs for debugging output during login
- [ ] Verify session persistence across subdomains
- [ ] Confirm authentication state is properly detected by frontend

## Expected Debug Output
```
OAuth callback - User authenticated: username
OAuth callback - Session ID: sess_123...
OAuth callback - Is authenticated: true
Auth check - Session ID: sess_123...
Auth check - Is authenticated: true
Auth check - User: username
```

This will help us identify exactly where the OAuth flow might be failing.