### PR TITLE
Fix CI/CD pipeline issues

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -136,6 +136,6 @@ jobs:
           output: 'trivy-results.sarif'
           
       - name: Upload Trivy scan results
-        uses: github/codeql-action/upload-sarif@v2
+        uses: github/codeql-action/upload-sarif@v3
         with:
           sarif_file: 'trivy-results.sarif'

--- a/package.json
+++ b/package.json
@@ -7,6 +7,7 @@
     "dev": "vite",
     "build": "tsc -b && vite build",
     "lint": "eslint .",
+    "typecheck": "tsc --noEmit",
     "preview": "vite preview",
     "server": "node server.js",
     "server:dev": "nodemon server.js",


### PR DESCRIPTION
## Summary
- Add missing `typecheck` script to package.json that was causing CI failures
- Update CodeQL Action from deprecated v2 to v3 in security scan workflow

## Changes Made
- **package.json**: Added `"typecheck": "tsc --noEmit"` script
- **.github/workflows/ci.yml**: Updated `github/codeql-action/upload-sarif@v2` to `@v3`

## Test Plan
- [x] Verify typecheck script works locally
- [x] Confirm CodeQL Action v3 is the latest stable version
- [ ] Wait for CI pipeline to pass without deprecated warnings
- [ ] Verify security scan uploads SARIF results successfully

## Fixes
- Resolves npm script error: "Missing script: typecheck"
- Eliminates GitHub deprecated action warnings for CodeQL v2
- Ensures consistent type checking across development and CI environments