### PR TITLE
Fix path-to-regexp parameter error for Express 5.1.0 compatibility

### DIFF
--- a/server.js
+++ b/server.js
@@ -572,7 +572,7 @@ if (process.env.NODE_ENV === 'production') {
 }
 
 // Catch-all route for dynamic endpoints
-app.all('/:path', captureRequest, async (req, res) => {
+app.all('/:path([0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12})', captureRequest, async (req, res) => {
   try {
     const { path } = req.params;
     let endpoint;


### PR DESCRIPTION
## Summary
- Fix TypeError: Missing parameter name error in production Docker builds
- Update dynamic endpoint route pattern to use explicit UUID regex validation
- Ensure compatibility with Express 5.1.0's stricter path-to-regexp validation

## Changes
- Modified `server.js` route pattern from `/:path` to `/:path([0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12})`
- Route now explicitly matches UUID format for endpoint paths
- Resolves production deployment failures with path-to-regexp errors

## Test Plan
- [x] Verify route still captures UUID-formatted endpoint paths correctly
- [x] Test that production Docker build completes without path-to-regexp errors
- [ ] Deploy to production and verify endpoint functionality
- [ ] Test webhook endpoints still receive and process requests correctly

## Context
Express 5.1.0 upgraded to path-to-regexp v8.x which requires explicit parameter patterns. The generic `/:path` pattern was causing validation errors during server startup in production Docker containers.