### PR TITLE
Fix remaining path-to-regexp parameter validation issues

### DIFF
--- a/server.js
+++ b/server.js
@@ -479,7 +479,7 @@ app.post('/api/endpoints', optionalAuth, async (req, res) => {
   }
 });
 
-app.delete('/api/endpoints/:id', optionalAuth, async (req, res) => {
+app.delete('/api/endpoints/:id([0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12})', optionalAuth, async (req, res) => {
   try {
     const { id } = req.params;
     
@@ -531,7 +531,7 @@ app.get('/api/requests', optionalAuth, async (req, res) => {
   }
 });
 
-app.get('/api/requests/:endpointId', optionalAuth, async (req, res) => {
+app.get('/api/requests/:endpointId([0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12})', optionalAuth, async (req, res) => {
   try {
     const { endpointId } = req.params;
     


### PR DESCRIPTION
## Summary
- Fix remaining route parameter validation issues for Express 5.1.0 compatibility
- Add explicit UUID regex validation to all remaining route parameters
- Complete the path-to-regexp fixes from PR #73

## Changes
- Update `/api/endpoints/:id` to use UUID pattern validation
- Update `/api/requests/:endpointId` to use UUID pattern validation
- Ensures all route parameters have explicit validation patterns

## Context
This is a follow-up to PR #73. After the initial fix, there were still two more routes with parameter validation issues that needed the same treatment for full Express 5.1.0 compatibility.

## Test Plan
- [x] Verify all API routes with UUID parameters work correctly
- [ ] Test production Docker build completes without any path-to-regexp errors
- [ ] Verify endpoint and request API functionality