### PR TITLE
Fix frontend backend URL configuration for production builds

### DIFF
--- a/Dockerfile.production
+++ b/Dockerfile.production
@@ -4,6 +4,8 @@ FROM node:22-alpine AS frontend-build
 
 # Build argument to force cache invalidation
 ARG CACHE_BUST=1
+# Build argument for Vite environment variables
+ARG VITE_BACKEND_URL
 
 WORKDIR /app
 
@@ -27,6 +29,9 @@ RUN echo "Cache bust: $CACHE_BUST" && \
     echo "Build date: $(date -u)" >> /app/build-info.txt && \
     echo "Git commit: $(git rev-parse --short HEAD 2>/dev/null || echo 'unknown')" >> /app/build-info.txt && \
     echo "Cache bust value: $CACHE_BUST" >> /app/build-info.txt
+
+# Set environment variable for Vite build
+ENV VITE_BACKEND_URL=$VITE_BACKEND_URL
 
 # Build the frontend
 RUN npm run build

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -8,6 +8,7 @@ services:
       no_cache: true
       args:
         CACHE_BUST: ${CACHE_BUST:-$(date +%s)}
+        VITE_BACKEND_URL: ${VITE_BACKEND_URL}
     ports:
       - "3001:3001"
     environment:


### PR DESCRIPTION
## Summary
Fixes frontend connection issues in production where the frontend was trying to connect to the wrong backend URL due to environment variable configuration problems.

## Problem
- Frontend was connecting to `https://hookdebug.com:3001` instead of `https://request.hookdebug.com`
- `VITE_BACKEND_URL` from `.env` was not being injected during Docker build
- Caused `ERR_CONNECTION_TIMED_OUT` errors in production

## Solution
- Added `VITE_BACKEND_URL` as build argument to `Dockerfile.production`
- Pass environment variable during Docker build process in `docker-compose.yml`
- Ensure Vite has access to backend URL during build time

## Changes
### Dockerfile.production
```dockerfile
# Build argument for Vite environment variables
ARG VITE_BACKEND_URL
# Set environment variable for Vite build
ENV VITE_BACKEND_URL=$VITE_BACKEND_URL
```

### docker-compose.yml
```yaml
args:
  CACHE_BUST: ${CACHE_BUST:-$(date +%s)}
  VITE_BACKEND_URL: ${VITE_BACKEND_URL}
```

## Test Plan
- [x] Verify VITE_BACKEND_URL is available during build
- [x] Confirm frontend uses correct backend URL in production
- [ ] Test production deployment resolves connection timeouts
- [ ] Verify all API calls work correctly

## Context
This is a follow-up fix to PR #75. After resolving the Express and Docker issues, this addresses the final piece - ensuring the frontend can properly connect to the backend in production.

With `.env` containing `VITE_BACKEND_URL=https://request.hookdebug.com`, the frontend will now correctly use this URL instead of falling back to the config.ts logic.