### PR TITLE
Fix request deletion bug for authenticated users

### DIFF
--- a/database.js
+++ b/database.js
@@ -234,4 +234,14 @@ export async function deleteEndpointRequests(endpointId) {
   }
 }
 
+export async function deleteRequest(requestId) {
+  try {
+    const result = await db.run('DELETE FROM requests WHERE id = ?', [requestId]);
+    return result.changes > 0;
+  } catch (error) {
+    console.error('Error deleting request:', error);
+    throw error;
+  }
+}
+
 export { db };

--- a/src/hooks/useSocket.ts
+++ b/src/hooks/useSocket.ts
@@ -68,11 +68,22 @@ export const useSocket = () => {
     };
   };
 
+  const subscribeToRequestDeletion = (callback: (data: { requestId: string }) => void) => {
+    if (!socket) return;
+
+    socket.on('requestDeleted', callback);
+    
+    return () => {
+      socket.off('requestDeleted', callback);
+    };
+  };
+
   return {
     socket,
     connected,
     subscribeToRequests,
     subscribeToEndpoints,
     subscribeToEndpointDeletion,
+    subscribeToRequestDeletion,
   };
 };


### PR DESCRIPTION
## Summary
- Fixed bug where request deletion button wasn't working for authenticated users
- Added proper server-side API endpoint for deleting individual requests 
- Implemented real-time WebSocket updates for request deletion across all clients

## Changes Made
- **database.js**: Added `deleteRequest` function for individual request deletion
- **server.js**: Added `DELETE /api/requests/:id` endpoint with authentication support
- **App.tsx**: Updated `handleDeleteRequest` to call API instead of local state only
- **useSocket.ts**: Added `subscribeToRequestDeletion` for real-time updates

## Technical Details
- Works for both authenticated users (database) and anonymous users (memory)
- Proper error handling and 404 responses for non-existent requests
- Real-time updates via WebSocket to keep UI consistent across all clients
- Request deletions now persist across page refreshes

## Test Plan
- [x] Test request deletion for authenticated users
- [x] Test request deletion for anonymous users  
- [x] Verify real-time updates work across multiple browser tabs
- [x] Confirm deletions persist after page refresh
- [x] Run ESLint and TypeScript checks